### PR TITLE
Fix support for localIdentName and aliases

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,8 +16,7 @@ module.exports = function (source, map) {
   var rootPath = query.rootPath || '/';
   var minimalJson = !!query.minimalJson;
   var options = this.options.extractCssModuleClassnames || {};
-
-  processCss(source, null, {
+  var processOpts = {
     mode: moduleMode ? 'local' : 'global',
     loaderContext: {
       options: {
@@ -28,10 +27,13 @@ module.exports = function (source, map) {
       loaderIndex: this.loaderIndex - 1,
       resource: this.resource,
       loaders: this.loaders,
-      request: this.request
+      request: this.request,
+      resourcePath: this.resourcePath
     },
     query: query
-  }, function(err, result) {
+  }
+
+  processCss(source, null, processOpts, function(err, result) {
     if (err) throw err;
 
     files[relativePath(currentFilePath)] = {};

--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+var assign = require('lodash.assign');
 var processCss = require('css-loader/lib/processCss');
 var loaderUtils = require('loader-utils');
 var mkpath = require('mkpath');
@@ -87,7 +88,7 @@ module.exports = function (source, map) {
     // the Webpack API to get all the aliases
     var resolveAliases = options.resolve && options.resolve.alias;
     var resolveLoaderAliases = options.resolveLoader && options.resolveLoader.alias;
-    return Object.assign({}, resolveAliases || {}, resolveLoaderAliases || {});
+    return assign({}, resolveAliases || {}, resolveLoaderAliases || {});
   }
 
   function isClassName (result, className) {

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ var timer;
 
 module.exports = function (source, map) {
   if (this.cacheable) this.cacheable();
-  var currentFilePath = this.resourcePath;
+  var resourcePath = this.resourcePath;
   var query = loaderUtils.parseQuery(this.query);
   var moduleMode = query.modules || query.module;
   var outputFile = query.outputFile;
@@ -28,35 +28,40 @@ module.exports = function (source, map) {
       resource: this.resource,
       loaders: this.loaders,
       request: this.request,
-      resourcePath: this.resourcePath
+      resourcePath: resourcePath
     },
     query: query
   }
+  var aliases = getAliases(this.options);
+  var importPath = path.relative(rootPath, resourcePath);
+
+  files[importPath] = files[importPath] || {};
 
   processCss(source, null, processOpts, function(err, result) {
     if (err) throw err;
 
-    files[relativePath(currentFilePath)] = {};
     Object.keys(result.exports).forEach(function(key) {
-      var classes = result.exports[key].split(/\s+/);
-      classes = classes.map(function (className) {
-        result.importItemRegExpG.lastIndex = 0;
 
-        if (result.importItemRegExpG.test(className)) {
-          var match = result.importItemRegExp.exec(className);
-          var idx = +match[1];
-          var importItem = result.importItems[idx];
-          var fullUrl = path.resolve(path.dirname(currentFilePath), importItem.url);
-          return [relativePath(fullUrl), importItem.export];
-        } else {
+      var classes = result.exports[key].split(/\s+/);
+
+      files[importPath][key] = classes.map(function (className) {
+
+        if (isClassName(result, className)) {
           return className;
         }
+
+        var importItem = getImportItem(result, className);
+        var resolvedPath = resolvePath(importItem.url);
+        var composesPath = resolvedPath || path.resolve(path.dirname(resourcePath), importItem.url);
+
+        return [ path.relative(rootPath, composesPath), importItem.export ];
+
       });
-      files[relativePath(currentFilePath)][key] = classes;
+
     });
 
     if (options.onOutput && typeof options.onOutput === 'function') {
-      options.onOutput(currentFilePath, files[relativePath(currentFilePath)], files);
+      options.onOutput(resourcePath, files[importPath], files);
     } else {
       if (!outputFile) {
         throw new Error('Missing outputFile parameter in extract-css-module-classnames-loader');
@@ -77,8 +82,41 @@ module.exports = function (source, map) {
     }
   });
 
-  function relativePath(fullPath) {
-    return path.relative(rootPath, fullPath);
+  function getAliases (options) {
+    // TODO: Investigate if there is a way to leverage
+    // the Webpack API to get all the aliases
+    var resolveAliases = options.resolve && options.resolve.alias;
+    var resolveLoaderAliases = options.resolveLoader && options.resolveLoader.alias;
+    return Object.assign({}, resolveAliases || {}, resolveLoaderAliases || {});
+  }
+
+  function isClassName (result, className) {
+    result.importItemRegExpG.lastIndex = 0;
+    return !result.importItemRegExpG.test(className);
+  }
+
+  /**
+   * Return the unaliased path of an aliased import (if any)
+   *
+   * @param  {String} importPath Import path (e.g. import 'path/to/foo.css')
+   * @return {String}            The relative path of an aliased import (if any),
+   *                             otherwise empty string
+   */
+  function resolvePath (importPath) {
+    // TODO: Investigate if there is a way to leverage
+    // the Webpack API to handle the alias resolution instead
+    return Object.keys(aliases).reduce(function (prev, alias) {
+      var regex = new RegExp('^' + alias, 'i');
+      if (!regex.test(importPath)) { return prev }
+      var unaliasedPath = importPath.replace(regex, aliases[alias]);
+      return path.resolve(rootPath, unaliasedPath);
+    }, '');
+  }
+
+  function getImportItem (result, className) {
+    var match = result.importItemRegExp.exec(className);
+    var idx = +match[1];
+    return result.importItems[idx];
   }
 
   return source;

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "css-loader": "^0.19.0",
     "loader-utils": "^0.2.11",
+    "lodash.assign": "^3.2.0",
     "mkpath": "^0.1.0"
   }
 }


### PR DESCRIPTION
- add support for `[path]` and `[name]` `localIdentName` patterns (mmrko/extract-css-module-classnames-loader/issues/1)
- add support for import aliases (mmrko/extract-css-module-classnames-loader/issues/2)

Thanks for this neat little loader! We are looking to utilize it in our QA environment by using the class name metadata to avoid hardcoding those nasty generated class names everywhere :)
